### PR TITLE
Removed duplicate CNAME file

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-runmachine.io


### PR DESCRIPTION
The CNAME file must exist at the root of the published
site (publishDir).